### PR TITLE
Remove deprecated duplicate macro exports

### DIFF
--- a/src/parse_generics_shim_util/parse_generics_shim.rs
+++ b/src/parse_generics_shim_util/parse_generics_shim.rs
@@ -7,13 +7,6 @@ Licensed under the MIT license (see LICENSE or <http://opensource.org
 files in the project carrying such notice may not be copied, modified,
 or distributed except according to those terms.
 */
-#[doc(hidden)]
-#[macro_export]
-macro_rules! parse_generics_shim {
-    ($($body:tt)*) => {
-        parse_generics! { $($body)* }
-    };
-}
 
 #[doc(hidden)]
 #[macro_export]

--- a/src/parse_generics_shim_util/parse_where_shim.rs
+++ b/src/parse_generics_shim_util/parse_where_shim.rs
@@ -7,13 +7,6 @@ Licensed under the MIT license (see LICENSE or <http://opensource.org
 files in the project carrying such notice may not be copied, modified,
 or distributed except according to those terms.
 */
-#[doc(hidden)]
-#[macro_export]
-macro_rules! parse_where_shim {
-    ($($body:tt)*) => {
-        parse_where! { $($body)* }
-    };
-}
 
 #[doc(hidden)]
 #[macro_export]


### PR DESCRIPTION
See https://github.com/rust-lang/rust/pull/50143 for more details.